### PR TITLE
Fix data race in queryAPI.queryURL()

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -232,7 +232,10 @@ func (q *queryAPI) QueryWithParams(ctx context.Context, query string, params int
 }
 
 func (q *queryAPI) queryURL() (string, error) {
-	if q.url == "" {
+	q.lock.Lock()
+	queryURL := q.url
+	q.lock.Unlock()
+	if queryURL == "" {
 		u, err := url.Parse(q.httpService.ServerAPIURL())
 		if err != nil {
 			return "", err
@@ -244,9 +247,10 @@ func (q *queryAPI) queryURL() (string, error) {
 		u.RawQuery = params.Encode()
 		q.lock.Lock()
 		q.url = u.String()
+		queryURL = q.url
 		q.lock.Unlock()
 	}
-	return q.url, nil
+	return queryURL, nil
 }
 
 // checkParamsType validates the value is struct with simple type fields


### PR DESCRIPTION
Output before fix: 
```go
$ go test -race ./...
ok      github.com/influxdata/influxdb-client-go/v2     (cached)
Req: {"query":"flux","type":"flux"}
==================
WARNING: DATA RACE
Read at 0x00c000482220 by goroutine 68:
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).queryURL()
      /Users/jared/influxdb-client-go/api/query.go:235 +0x38
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).QueryWithParams()
      /Users/jared/influxdb-client-go/api/query.go:195 +0xa8
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).Query()
      /Users/jared/influxdb-client-go/api/query.go:187 +0x54
  github.com/influxdata/influxdb-client-go/v2/api.TestParallelQueries.func2()
      /Users/jared/influxdb-client-go/api/query_test.go:1076 +0x78

Previous write at 0x00c000482220 by goroutine 67:
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).queryURL()
      /Users/jared/influxdb-client-go/api/query.go:246 +0x248
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).QueryWithParams()
      /Users/jared/influxdb-client-go/api/query.go:195 +0xa8
  github.com/influxdata/influxdb-client-go/v2/api.(*queryAPI).Query()
      /Users/jared/influxdb-client-go/api/query.go:187 +0x54
  github.com/influxdata/influxdb-client-go/v2/api.TestParallelQueries.func2()
      /Users/jared/influxdb-client-go/api/query_test.go:1076 +0x78

Goroutine 68 (running) created at:
  github.com/influxdata/influxdb-client-go/v2/api.TestParallelQueries()
      /Users/jared/influxdb-client-go/api/query_test.go:1075 +0x1c4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44

Goroutine 67 (running) created at:
  github.com/influxdata/influxdb-client-go/v2/api.TestParallelQueries()
      /Users/jared/influxdb-client-go/api/query_test.go:1075 +0x1c4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x18c
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x44
==================
--- FAIL: TestParallelQueries (0.00s)
    testing.go:1312: race detected during execution of test
[logs omitted for brevity]
FAIL
FAIL    github.com/influxdata/influxdb-client-go/v2/api 2.727s
ok      github.com/influxdata/influxdb-client-go/v2/api/http    (cached)
ok      github.com/influxdata/influxdb-client-go/v2/api/query   (cached)
ok      github.com/influxdata/influxdb-client-go/v2/api/write   (cached)
?       github.com/influxdata/influxdb-client-go/v2/domain      [no test files]
?       github.com/influxdata/influxdb-client-go/v2/internal/examples   [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/gzip       (cached)
?       github.com/influxdata/influxdb-client-go/v2/internal/http       [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/log        (cached)
?       github.com/influxdata/influxdb-client-go/v2/internal/test       [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/write      (cached)
ok      github.com/influxdata/influxdb-client-go/v2/log (cached)
FAIL
```

Output after fix:
```go
$ go test -race ./...
ok      github.com/influxdata/influxdb-client-go/v2     4.239s
ok      github.com/influxdata/influxdb-client-go/v2/api 2.704s
ok      github.com/influxdata/influxdb-client-go/v2/api/http    (cached)
ok      github.com/influxdata/influxdb-client-go/v2/api/query   (cached)
ok      github.com/influxdata/influxdb-client-go/v2/api/write   (cached)
?       github.com/influxdata/influxdb-client-go/v2/domain      [no test files]
?       github.com/influxdata/influxdb-client-go/v2/internal/examples   [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/gzip       (cached)
?       github.com/influxdata/influxdb-client-go/v2/internal/http       [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/log        (cached)
?       github.com/influxdata/influxdb-client-go/v2/internal/test       [no test files]
ok      github.com/influxdata/influxdb-client-go/v2/internal/write      (cached)
ok      github.com/influxdata/influxdb-client-go/v2/log (cached)
```